### PR TITLE
[#8] Bugfix lightdm API functions

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -35,11 +35,11 @@ function select_user_from_list(idx, err)
 	if(!err)
     	find_and_display_user_picture(idx);
 
-    if(lightdm._username){
+    if(lightdm.authentication_user){
         lightdm.cancel_authentication();
     }
 
-    selected_user = lightdm.users[idx].name;
+    selected_user = lightdm.users[idx].username;
     if(selected_user !== null) {
         start_authentication(selected_user);
     }
@@ -49,13 +49,13 @@ function select_user_from_list(idx, err)
 
 function start_authentication(username)
 {
-   lightdm.cancel_timed_login ();
+   lightdm.cancel_autologin();
    label = document.getElementById('countdown_label');
    if (label != null)
        label.style.visibility = "false";
 	
 	selected_user = username;
-    lightdm.start_authentication(username);
+    lightdm.authenticate(username);
     
     show_message("?");
 }
@@ -64,7 +64,8 @@ function authentication_complete()
 {
     if (lightdm.is_authenticated)
     	//lightdm.login (lightdm.authentication_user, lightdm.default_session); for lightdm-webkit-greeter
-	lightdm.login (lightdm.authentication_user, lightdm.start_session_sync, 'gnome'); //lightdm-webkit2-greeter
+      //lightdm.login (lightdm.authentication_user, lightdm.start_session_sync, 'gnome'); //lightdm-webkit2-greeter
+      lightdm.start_session('gnome');
     else
    	{
     	select_user_from_list(curr-1, true);
@@ -91,11 +92,12 @@ function provide_secret()
 {
   	password = $pass.val() || null;
   	if(password !== null)
-        lightdm.provide_secret(password);
+        lightdm.respond(password);
 }
 
 function init()
 {
+    lightdm.authentication_complete.connect(authentication_complete);
     setup_users_list();
     select_user_from_list(0, false);
     show_message ("&nbsp");

--- a/static/style.css
+++ b/static/style.css
@@ -79,6 +79,7 @@ body
 	margin-top:40px;
 	height:7em;
 	-webkit-transition:opacity .5s ease-in-out;
+  transition:opacity .5s ease-in-out;
 }
 
 #login-response
@@ -121,7 +122,7 @@ body
 #last,
 #next
 {
-	color:#ffffff;
+	color:#e6e6e6;
 	font-family:"Balsamiq-sans";
 }
 
@@ -138,7 +139,6 @@ body
 	right:135px;
 	left:-20px;
 	width:12px;
-	color:#ffffff;
 }
 
 #container
@@ -163,6 +163,7 @@ body
     /* margin-bottom: 13px; */
     border-spacing: 31px 0px;
     -webkit-transition:margin .8s ease-in-out;
+    transition:margin .8s ease-in-out;
     text-align:center;
     background-color: #f9f9f9;
 }


### PR DESCRIPTION
Fix #8

lightdm-webkit2-greeter is no longer maintained, use [web-greeter](https://github.com/JezerM/web-greeter) or [nody-greeter](https://github.com/JezerM/nody-greeter) instead.

## Changes

- `lightdm.start_authentication` replaced with `lightdm.authenticate`
- `lightdm.provide_response` replaced with `lightdm.respond`
- `lightdm.cancel_timed_login` replaced with `lightdm.cancel_autologin`
- `lightdm.login` replaced with `lightdm.start_session`
- Added `authentication_complete` signal
- Last and Next buttons are now a bit visible
